### PR TITLE
Adjust brightness

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -18,7 +18,9 @@ pub const EDIT_SELECT_ALL: Selector = Selector::new("edit-select-all");
 pub const EDIT_DESELECT: Selector = Selector::new("edit-deselect");
 
 pub const IMAGE_BLACK_AND_WHITE: Selector = Selector::new("image-black-and-white");
+pub const IMAGE_BRIGHTEN: Selector = Selector::new("image-brighten");
 pub const IMAGE_CLEAR: Selector = Selector::new("image-clear");
+pub const IMAGE_DARKEN: Selector = Selector::new("image-darken");
 pub const IMAGE_DESATURATE: Selector = Selector::new("image-desaturate");
 pub const IMAGE_DITHER_FLOYD: Selector = Selector::new("image-dither-floyd");
 pub const IMAGE_ERASER: Selector = Selector::new("image-eraser");

--- a/src/controller/delegate.rs
+++ b/src/controller/delegate.rs
@@ -83,8 +83,16 @@ impl druid::AppDelegate<AppState> for Delegate {
                 controller::image::black_and_white(ctx, cmd, data);
                 druid::Handled::Yes
             }
+            _ if cmd.is(commands::IMAGE_BRIGHTEN) => {
+                controller::image::brighten(ctx, cmd, data);
+                druid::Handled::Yes
+            }
             _ if cmd.is(commands::IMAGE_CLEAR) => {
                 controller::image::clear(ctx, cmd, data);
+                druid::Handled::Yes
+            }
+            _ if cmd.is(commands::IMAGE_DARKEN) => {
+                controller::image::darken(ctx, cmd, data);
                 druid::Handled::Yes
             }
             _ if cmd.is(commands::IMAGE_DESATURATE) => {

--- a/src/controller/image.rs
+++ b/src/controller/image.rs
@@ -20,9 +20,15 @@ pub fn black_and_white(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, dat
     transforms::apply(data, transforms::colors::black_and_white);
 }
 
+pub fn brighten(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
+    transforms::apply(data, transforms::colors::brighten);
+}
+
 pub fn clear(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
     transforms::apply(data, transforms::simple::clear);
 }
+
+pub fn darken(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, _data: &mut AppState) {}
 
 pub fn desaturate(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
     transforms::apply(data, transforms::colors::desaturate);

--- a/src/controller/image.rs
+++ b/src/controller/image.rs
@@ -17,25 +17,27 @@ use crate::model::app_state::AppState;
 use crate::transforms;
 
 pub fn black_and_white(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
-    transforms::apply(data, transforms::colors::black_and_white);
+    transforms::apply(data, transforms::colors::black_and_white, 0.0);
 }
 
 pub fn brighten(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
-    transforms::apply(data, transforms::colors::brighten);
+    transforms::apply(data, transforms::colors::brightness, 0.05);
 }
 
 pub fn clear(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
-    transforms::apply(data, transforms::simple::clear);
+    transforms::apply(data, transforms::simple::clear, 0.0);
 }
 
-pub fn darken(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, _data: &mut AppState) {}
+pub fn darken(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
+    transforms::apply(data, transforms::colors::brightness, -0.05);
+}
 
 pub fn desaturate(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
-    transforms::apply(data, transforms::colors::desaturate);
+    transforms::apply(data, transforms::colors::desaturate, 0.0);
 }
 
 pub fn dither_floyd(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
-    transforms::apply(data, transforms::colors::dither_floyd);
+    transforms::apply(data, transforms::colors::dither_floyd, 0.0);
 }
 
 pub fn eraser(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
@@ -46,7 +48,7 @@ pub fn eraser(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut A
 }
 
 pub fn fill(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
-    transforms::apply(data, transforms::colors::fill);
+    transforms::apply(data, transforms::colors::fill, 0.0);
 }
 
 pub fn marquee(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {

--- a/src/model/pixel_env.rs
+++ b/src/model/pixel_env.rs
@@ -17,10 +17,16 @@ pub struct PixelEnv {
     pub color: druid::Color,
     pub pos: druid::Point,
     pub bounds: druid::Rect,
+    pub param: f64,
 }
 
 impl PixelEnv {
-    pub fn new(color: druid::Color, pos: druid::Point, bounds: druid::Rect) -> Self {
-        Self { color, pos, bounds }
+    pub fn new(color: druid::Color, pos: druid::Point, bounds: druid::Rect, param: f64) -> Self {
+        Self {
+            color,
+            pos,
+            bounds,
+            param,
+        }
     }
 }

--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -23,7 +23,7 @@ pub mod colors;
 pub mod simple;
 mod util;
 
-pub fn apply<F>(data: &mut AppState, f: F)
+pub fn apply<F>(data: &mut AppState, f: F, param: f64)
 where
     F: Fn(&PixelHeader, &PixelEnv, &mut Vec<u8>),
 {
@@ -32,7 +32,7 @@ where
     let bounds = data.get_bounds();
     undo::push(data, bounds);
 
-    let env = PixelEnv::new(data.brush_color.clone(), data.current_pos, bounds);
+    let env = PixelEnv::new(data.brush_color.clone(), data.current_pos, bounds, param);
     let bytes = Arc::make_mut(&mut data.doc.pixels.bytes);
 
     f(&data.doc.pixels.header, &env, bytes);

--- a/src/transforms/colors.rs
+++ b/src/transforms/colors.rs
@@ -29,11 +29,11 @@ pub fn black_and_white(header: &PixelHeader, env: &PixelEnv, bytes: &mut Vec<u8>
     }
 }
 
-pub fn brighten(header: &PixelHeader, env: &PixelEnv, bytes: &mut Vec<u8>) {
+pub fn brightness(header: &PixelHeader, env: &PixelEnv, bytes: &mut Vec<u8>) {
     for y in env.bounds.y0 as usize..env.bounds.y1 as usize {
         for x in env.bounds.x0 as usize..env.bounds.x1 as usize {
             let color = util::read(x, y, header, bytes);
-            let new_color = util::brightness(&color, 0.05);
+            let new_color = util::brightness(&color, env.param);
             util::write(x, y, header, bytes, &new_color);
         }
     }

--- a/src/transforms/colors.rs
+++ b/src/transforms/colors.rs
@@ -29,6 +29,16 @@ pub fn black_and_white(header: &PixelHeader, env: &PixelEnv, bytes: &mut Vec<u8>
     }
 }
 
+pub fn brighten(header: &PixelHeader, env: &PixelEnv, bytes: &mut Vec<u8>) {
+    for y in env.bounds.y0 as usize..env.bounds.y1 as usize {
+        for x in env.bounds.x0 as usize..env.bounds.x1 as usize {
+            let color = util::read(x, y, header, bytes);
+            let new_color = util::brightness(&color, 0.05);
+            util::write(x, y, header, bytes, &new_color);
+        }
+    }
+}
+
 /// Desaturate pixels (make them grayscale).
 pub fn desaturate(header: &PixelHeader, env: &PixelEnv, bytes: &mut Vec<u8>) {
     for y in env.bounds.y0 as usize..env.bounds.y1 as usize {

--- a/src/transforms/util.rs
+++ b/src/transforms/util.rs
@@ -123,7 +123,7 @@ pub fn hsla_to_rgba(hue: f64, saturation: f64, luminance: f64, alpha: f64) -> (f
         }
 
         if t2 < 1.0 / 6.0 {
-            return p + (q - p) * 6.0 / t2;
+            return p + (q - p) * 6.0 * t2;
         }
         if t2 < 0.5 {
             return q;

--- a/src/transforms/util.rs
+++ b/src/transforms/util.rs
@@ -61,6 +61,7 @@ pub fn desaturate(color: &druid::Color) -> druid::Color {
     druid::Color::rgba(gray, gray, gray, a)
 }
 
+/// Convert RGBA bytes to HSLA.
 pub fn rgba8_to_hsla(red: u8, green: u8, blue: u8, alpha: u8) -> (f64, f64, f64, f64) {
     rgba_to_hsla(
         f64_round(red as f64 / 255.0),
@@ -70,6 +71,7 @@ pub fn rgba8_to_hsla(red: u8, green: u8, blue: u8, alpha: u8) -> (f64, f64, f64,
     )
 }
 
+/// Convert RGBA float values to HSLA.
 pub fn rgba_to_hsla(red: f64, green: f64, blue: f64, alpha: f64) -> (f64, f64, f64, f64) {
     let maxv = f64_max3(red, green, blue);
     let minv = f64_min3(red, green, blue);
@@ -108,6 +110,7 @@ pub fn rgba_to_hsla(red: f64, green: f64, blue: f64, alpha: f64) -> (f64, f64, f
     (hue, saturation, luminance, alpha)
 }
 
+/// Convert HSLA to RGBA float values.
 pub fn hsla_to_rgba(hue: f64, saturation: f64, luminance: f64, alpha: f64) -> (f64, f64, f64, f64) {
     fn hue_to_rgb(p: f64, q: f64, t: f64) -> f64 {
         let mut t2 = t;

--- a/src/transforms/util.rs
+++ b/src/transforms/util.rs
@@ -61,6 +61,16 @@ pub fn desaturate(color: &druid::Color) -> druid::Color {
     druid::Color::rgba(gray, gray, gray, a)
 }
 
+/// Modify brightness of the given color. Can be positive or negative.
+pub fn brightness(color: &druid::Color, val: f64) -> druid::Color {
+    let (red, green, blue, alpha) = color.as_rgba();
+    let (hue, saturation, luminance, alpha) = rgba_to_hsla(red, green, blue, alpha);
+    let new_luminance = f64::max(f64::min(luminance + val, 1.0), 0.0);
+    let (new_red, new_green, new_blue, _) = hsla_to_rgba(hue, saturation, new_luminance, alpha);
+
+    druid::Color::rgba(new_red, new_green, new_blue, alpha)
+}
+
 /// Convert RGBA bytes to HSLA.
 pub fn rgba8_to_hsla(red: u8, green: u8, blue: u8, alpha: u8) -> (f64, f64, f64, f64) {
     rgba_to_hsla(

--- a/src/view/menu.rs
+++ b/src/view/menu.rs
@@ -171,6 +171,20 @@ fn build_edit_menu<T: Data>(menu_opts: &MenuOpts) -> druid::MenuDesc<T> {
 }
 
 fn build_image_menu<T: Data>() -> druid::MenuDesc<T> {
+    fn brighten<T: Data>() -> druid::MenuItem<T> {
+        druid::MenuItem::new(
+            druid::LocalizedString::new("menu-image-brighten").with_placeholder("Brighten"),
+            commands::IMAGE_BRIGHTEN,
+        )
+    }
+
+    fn darken<T: Data>() -> druid::MenuItem<T> {
+        druid::MenuItem::new(
+            druid::LocalizedString::new("menu-image-darken").with_placeholder("Darken"),
+            commands::IMAGE_DARKEN,
+        )
+    }
+
     fn black_and_white<T: Data>() -> druid::MenuItem<T> {
         druid::MenuItem::new(
             druid::LocalizedString::new("menu-image-black-and-white")
@@ -195,6 +209,9 @@ fn build_image_menu<T: Data>() -> druid::MenuDesc<T> {
     }
 
     druid::MenuDesc::new(druid::LocalizedString::new("menu-image-menu").with_placeholder("Image"))
+        .append(brighten())
+        .append(darken())
+        .append_separator()
         .append(black_and_white())
         .append(desaturate())
         .append(dither_floyd())


### PR DESCRIPTION
The lame way, with separate menu items.

I'm super unhappy with the rounding. Without it, little errors with propagate, and it becomes impossible to reverse the conversion, i.e., RGB(HSL(A)) != A. I'm thinking of moving the rounding directly into the tests just for the comparisons.