### PR TITLE
Of course, B&W can use the param as the threshold

### DIFF
--- a/src/controller/image.rs
+++ b/src/controller/image.rs
@@ -17,7 +17,7 @@ use crate::model::app_state::AppState;
 use crate::transforms;
 
 pub fn black_and_white(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
-    transforms::apply(data, transforms::colors::black_and_white, 0.0);
+    transforms::apply(data, transforms::colors::black_and_white, 0.5);
 }
 
 pub fn brighten(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {

--- a/src/transforms/colors.rs
+++ b/src/transforms/colors.rs
@@ -23,7 +23,7 @@ pub fn black_and_white(header: &PixelHeader, env: &PixelEnv, bytes: &mut Vec<u8>
     for y in env.bounds.y0 as usize..env.bounds.y1 as usize {
         for x in env.bounds.x0 as usize..env.bounds.x1 as usize {
             let color = util::read(x, y, header, bytes);
-            let bw = util::black_and_white(&color, 0.5);
+            let bw = util::black_and_white(&color, env.param);
             util::write(x, y, header, bytes, &bw);
         }
     }

--- a/src/transforms/util.rs
+++ b/src/transforms/util.rs
@@ -88,7 +88,7 @@ pub fn rgba_to_hsla(red: f64, green: f64, blue: f64, alpha: f64) -> (f64, f64, f
 
     let mut hue = 0.0;
     let mut saturation = 0.0;
-    let mut luminance = (maxv + minv) / 2.0;
+    let luminance = (maxv + minv) / 2.0;
 
     if !f64_eq(maxv, minv) {
         let d = maxv - minv;
@@ -112,10 +112,6 @@ pub fn rgba_to_hsla(red: f64, green: f64, blue: f64, alpha: f64) -> (f64, f64, f
 
         hue /= 6.0;
     }
-
-    hue = hue;
-    saturation = saturation;
-    luminance = luminance;
 
     (hue, saturation, luminance, alpha)
 }


### PR DESCRIPTION
The param we introduced for brightness works great for the B&W threshold. We really need a tool window with sliders, but such is life.

Also clippy found some unused assignments.