### PR TITLE
This warning annoys me

### DIFF
--- a/src/view/canvas.rs
+++ b/src/view/canvas.rs
@@ -249,7 +249,6 @@ impl druid::Widget<AppState> for Canvas {
             Event::MouseMove(e) => {
                 let cursor = match data.tool_type {
                     ToolType::Marquee => druid::Cursor::Crosshair,
-                    ToolType::Move => druid::Cursor::OpenHand,
                     _ => druid::Cursor::Arrow,
                 };
                 ctx.set_cursor(&cursor);


### PR DESCRIPTION
`warning: use of deprecated variant `druid::Cursor::OpenHand`: this will be removed in future because it is not available on windows`