### PR TITLE
Expand the canvas

### DIFF
--- a/src/controller/file.rs
+++ b/src/controller/file.rs
@@ -70,7 +70,9 @@ pub fn save(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut App
 
     if let Some(path) = data.doc().path() {
         match storage::png::write_path(&path, data.doc().pixels()) {
-            Ok(()) => {}
+            Ok(()) => {
+                data.doc.pixels_mut().clear_dirty();
+            }
             Err(_e) => {}
         };
     }
@@ -88,6 +90,7 @@ pub fn save_as(ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut Ap
             if data.window_state() == WindowState::UnsavedSave {
                 open_internal(ctx, cmd, data);
             } else {
+                data.doc.pixels_mut().clear_dirty();
                 data.doc.set_path(String::from(path));
             }
         }

--- a/src/controller/image.rs
+++ b/src/controller/image.rs
@@ -45,9 +45,8 @@ pub fn eraser(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut A
     let current_pos = data.current_pos();
     undo::push_point(data, current_pos);
 
-    let idx = data.doc().pixels().point_to_idx(current_pos);
     let color = druid::Color::rgba8(0, 0, 0, 0);
-    data.doc.pixels_mut().write(idx, &color);
+    data.doc.pixels_mut().write(current_pos, &color);
 }
 
 pub fn fill(_ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppState) {
@@ -82,7 +81,6 @@ pub fn paint(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut Ap
     let current_pos = data.current_pos();
     undo::push_point(data, current_pos);
 
-    let idx = data.doc().pixels().point_to_idx(current_pos);
     let color = data.brush_color().clone();
-    data.doc.pixels_mut().write(idx, &color);
+    data.doc.pixels_mut().write(current_pos, &color);
 }

--- a/src/model/pixels.rs
+++ b/src/model/pixels.rs
@@ -35,14 +35,17 @@ impl PixelHeader {
         }
     }
 
+    /// Get the width, in pixels.
     pub fn width(&self) -> usize {
         self.width as usize
     }
 
+    /// Get the height, in pixels.
     pub fn height(&self) -> usize {
         self.height as usize
     }
 
+    /// Get the number of bytes per pixel.
     pub fn bytes_per_pixel(&self) -> u8 {
         self.bytes_per_pixel
     }
@@ -82,18 +85,22 @@ impl PixelEnv {
         }
     }
 
+    /// Get the current color.
     pub fn color(&self) -> &druid::Color {
         &self.color
     }
 
+    /// Get the current mouse position.
     pub fn pos(&self) -> druid::Point {
         self.pos
     }
 
+    /// Get the bounds. Can be selection or entire image.
     pub fn bounds(&self) -> druid::Rect {
         self.bounds
     }
 
+    /// Get the parameter that was passed.
     pub fn param(&self) -> f64 {
         self.param
     }
@@ -122,28 +129,34 @@ impl PixelState {
         }
     }
 
+    /// Are pixels dirty?
     pub fn dirty(&self) -> bool {
         self.dirty
     }
 
+    /// Get the pixel header.
     pub fn header(&self) -> &PixelHeader {
         &self.header
     }
 
+    /// Get pixel bytes.
     pub fn bytes(&self) -> &Vec<u8> {
         &self.bytes
     }
 
+    /// Set the pixel bytes.
     pub fn set_bytes(&mut self, bytes: Vec<u8>) {
         self.bytes = Arc::new(bytes);
         self.dirty = true;
     }
 
+    /// Determine if the given point is contained within the pixel bounds.
     #[inline]
     pub fn contains(&self, p: druid::Point) -> bool {
         self.contains_xy(p.x as usize, p.y as usize)
     }
 
+    /// Determine if the given point is contained with the pixel bounds.
     #[inline]
     pub fn contains_xy(&self, x: usize, y: usize) -> bool {
         x > 0 && y > 0 && x <= self.header.width() && y <= self.header.height()

--- a/src/model/pixels.rs
+++ b/src/model/pixels.rs
@@ -26,17 +26,7 @@ pub struct PixelHeader {
 }
 
 impl PixelHeader {
-    const DEFAULT_WIDTH: u32 = 32;
-    const DEFAULT_HEIGHT: u32 = 32;
-    const DEFAULT_DEPTH: u8 = 8;
-    const DEFAULT_BYTES_PER_PIXEL: u8 = 4;
-
     pub fn new(width: u32, height: u32, depth: u8, bytes_per_pixel: u8) -> Self {
-        assert!(width == Self::DEFAULT_WIDTH);
-        assert!(height == Self::DEFAULT_HEIGHT);
-        assert!(depth == Self::DEFAULT_DEPTH);
-        assert!(bytes_per_pixel == Self::DEFAULT_BYTES_PER_PIXEL);
-
         Self {
             width,
             height,
@@ -66,10 +56,10 @@ impl PixelHeader {
 impl Default for PixelHeader {
     fn default() -> Self {
         Self {
-            width: Self::DEFAULT_WIDTH,
-            height: Self::DEFAULT_HEIGHT,
-            depth: Self::DEFAULT_DEPTH,
-            bytes_per_pixel: Self::DEFAULT_BYTES_PER_PIXEL,
+            width: 32,
+            height: 32,
+            depth: 8,
+            bytes_per_pixel: 4,
         }
     }
 }

--- a/src/model/pixels.rs
+++ b/src/model/pixels.rs
@@ -150,10 +150,21 @@ impl PixelState {
     }
 
     #[inline]
+    pub fn contains(&self, p: druid::Point) -> bool {
+        self.contains_xy(p.x as usize, p.y as usize)
+    }
+
+    #[inline]
+    pub fn contains_xy(&self, x: usize, y: usize) -> bool {
+        x > 0 && y > 0 && x <= self.header.width() && y <= self.header.height()
+    }
+
+    #[inline]
     fn xy_to_idx(&self, x: usize, y: usize) -> usize {
+        assert!(x > 0);
+        assert!(y > 0);
         let stride = self.header.width();
-        let idx = (y - 1) * stride + (x - 1);
-        idx * self.header.bytes_per_pixel as usize
+        (y - 1) * stride + (x - 1)
     }
 
     #[inline]
@@ -162,7 +173,6 @@ impl PixelState {
     }
 
     /// Read from an xy point in pixel storage.
-    #[inline]
     pub fn read_xy(&self, x: usize, y: usize) -> druid::Color {
         let byte_idx = self.xy_to_byte_idx(x, y);
 
@@ -199,7 +209,6 @@ impl PixelState {
     }
 
     /// Write to a point in pixel storage.
-    #[inline]
     pub fn write(&mut self, p: druid::Point, color: &druid::Color) {
         let byte_idx = self.xy_to_byte_idx(p.x as usize, p.y as usize);
         let (red, green, blue, alpha) = color.as_rgba8();

--- a/src/model/pixels.rs
+++ b/src/model/pixels.rs
@@ -56,8 +56,8 @@ impl PixelHeader {
 impl Default for PixelHeader {
     fn default() -> Self {
         Self {
-            width: 32,
-            height: 32,
+            width: 48,
+            height: 48,
             depth: 8,
             bytes_per_pixel: 4,
         }

--- a/src/model/pixels.rs
+++ b/src/model/pixels.rs
@@ -134,6 +134,11 @@ impl PixelState {
         self.dirty
     }
 
+    /// Clear dirty flag.
+    pub fn clear_dirty(&mut self) {
+        self.dirty = false;
+    }
+
     /// Get the pixel header.
     pub fn header(&self) -> &PixelHeader {
         &self.header

--- a/src/view/canvas.rs
+++ b/src/view/canvas.rs
@@ -113,8 +113,9 @@ impl Canvas {
     /// Paint pixels from storage onto the given render context. This will paint
     /// on top of the checkboard. Pixel transparency is via alpha value.
     fn paint_pixels(&self, ctx: &mut PaintCtx, data: &AppState) {
-        let height = data.doc().pixels().header().height();
-        let width = data.doc().pixels().header().width();
+        let header = data.doc().pixels().header();
+        let height = header.height();
+        let width = header.width();
 
         for y in 1..height + 1 {
             for x in 1..width + 1 {
@@ -146,8 +147,9 @@ impl Canvas {
     /// Paint the grid onto the given render context.
     fn paint_grid(&self, ctx: &mut PaintCtx, data: &AppState) {
         if data.show_grid() {
-            let height = data.doc().pixels().header().height();
-            let width = data.doc().pixels().header().width();
+            let header = data.doc().pixels().header();
+            let height = header.height();
+            let width = header.width();
 
             let num_lines = width / 8 + 1;
             for i in 1..num_lines {

--- a/src/view/canvas.rs
+++ b/src/view/canvas.rs
@@ -47,9 +47,9 @@ impl Canvas {
             return None;
         }
 
-        let x = pos.x as usize / (theme::PIXEL_SIZE as usize) + 1;
-        let y = pos.y as usize / (theme::PIXEL_SIZE as usize) + 1;
-        if x > theme::COLS || y > theme::ROWS {
+        let x = pos.x as usize / (theme::CANVAS_PIXEL_SIZE as usize) + 1;
+        let y = pos.y as usize / (theme::CANVAS_PIXEL_SIZE as usize) + 1;
+        if x > theme::CANVAS_COLS || y > theme::CANVAS_ROWS {
             return None;
         }
 
@@ -64,22 +64,18 @@ impl Canvas {
     fn canvas_coords_to_screen_coords_f64(x: f64, y: f64) -> druid::Point {
         assert!(x > 0.0 && y > 0.0);
         druid::Point::new(
-            1.0 + ((x - 1.0) * theme::PIXEL_SIZE),
-            1.0 + ((y - 1.0) * theme::PIXEL_SIZE),
+            1.0 + ((x - 1.0) * theme::CANVAS_PIXEL_SIZE),
+            1.0 + ((y - 1.0) * theme::CANVAS_PIXEL_SIZE),
         )
     }
 
     /// Convert an index within the canvas storage to a rectanble in screen coordinates.
     fn screen_rect(x: usize, y: usize) -> druid::Rect {
-        let fx = (x - 1) as f64;
-        let fy = (y - 1) as f64;
+        let fx = x as f64;
+        let fy = y as f64;
+        let origin = Self::canvas_coords_to_screen_coords_f64(fx, fy);
 
-        let origin = druid::Point::new(
-            1.0 + (fx * theme::PIXEL_SIZE),
-            1.0 + (fy * theme::PIXEL_SIZE),
-        );
-
-        druid::Rect::from_origin_size(origin, (theme::PIXEL_SIZE, theme::PIXEL_SIZE))
+        druid::Rect::from_origin_size(origin, (theme::CANVAS_PIXEL_SIZE, theme::CANVAS_PIXEL_SIZE))
     }
 
     fn read_safe(data: &AppState, p: druid::Point) -> druid::Color {
@@ -319,7 +315,7 @@ impl druid::Widget<AppState> for Canvas {
         _data: &AppState,
         _env: &Env,
     ) -> Size {
-        let rect = Self::screen_rect(theme::ROWS, theme::COLS);
+        let rect = Self::screen_rect(theme::CANVAS_ROWS, theme::CANVAS_COLS);
         let size = Size::new(rect.x1 + 1.0, rect.y1 + 1.0);
         bc.constrain(size)
     }

--- a/src/view/canvas.rs
+++ b/src/view/canvas.rs
@@ -27,8 +27,8 @@ pub struct Canvas {
 }
 
 impl Canvas {
-    const COLS: usize = 32;
-    const ROWS: usize = 32;
+    const COLS: usize = 48;
+    const ROWS: usize = 48;
     const PIXELS: f64 = 16.0;
 
     /// Create an empty canvas.
@@ -117,10 +117,10 @@ impl Canvas {
     /// Paint pixels from storage onto the given render context. This will paint
     /// on top of the checkboard. Pixel transparency is via alpha value.
     fn paint_pixels(&self, ctx: &mut PaintCtx, data: &AppState) {
-        let pixels = data.doc().pixels();
-        for i in 0..pixels.len() {
-            Self::paint_idx(ctx, i, &pixels.read(i));
-        }
+        //let pixels = data.doc().pixels();
+        //for i in 0..pixels.len() {
+        //    Self::paint_idx(ctx, i, &pixels.read(i));
+        //}
     }
 
     /// Paint a grid line onto the given render context.
@@ -145,7 +145,8 @@ impl Canvas {
     /// Paint the grid onto the given render context.
     fn paint_grid(&self, ctx: &mut PaintCtx, data: &AppState) {
         if data.show_grid() {
-            for i in 1..4 {
+            let num_lines = Self::COLS / 8 + 1;
+            for i in 1..num_lines {
                 let offset = 1 + i * 8;
                 self.paint_grid_line(ctx, offset, 1, offset, Self::ROWS + 1);
                 self.paint_grid_line(ctx, 1, offset, Self::COLS + 1, offset);
@@ -181,8 +182,7 @@ impl Canvas {
     fn tool(&mut self, ctx: &mut EventCtx, data: &mut AppState, p: druid::Point) {
         match data.tool_type() {
             ToolType::Dropper => {
-                let idx = data.doc().pixels().point_to_idx(p);
-                let color = data.doc().pixels().read(idx);
+                let color = data.doc().pixels().read(p);
                 data.set_brush_color(color);
             }
 
@@ -262,8 +262,7 @@ impl druid::Widget<AppState> for Canvas {
                         // canvas coords have changed (because of how big our pixels are).
                         // Avoid doing any work if we're still in the same place.
                         if p != data.current_pos() {
-                            let idx = data.doc().pixels().point_to_idx(p);
-                            let color = data.doc().pixels().read(idx);
+                            let color = data.doc().pixels().read(p);
 
                             data.set_pos_color(color);
                             data.set_current_pos(p);
@@ -309,10 +308,10 @@ impl druid::Widget<AppState> for Canvas {
         &mut self,
         _layout_ctx: &mut LayoutCtx,
         bc: &BoxConstraints,
-        data: &AppState,
+        _data: &AppState,
         _env: &Env,
     ) -> Size {
-        let rect = Self::idx_to_screen_rect(data.doc().pixels().len() - 1);
+        let rect = Self::idx_to_screen_rect(Self::ROWS * Self::COLS - 1);
         let size = Size::new(rect.x1 + 1.0, rect.y1 + 1.0);
         bc.constrain(size)
     }

--- a/src/view/canvas.rs
+++ b/src/view/canvas.rs
@@ -27,10 +27,6 @@ pub struct Canvas {
 }
 
 impl Canvas {
-    const COLS: usize = 48;
-    const ROWS: usize = 48;
-    const PIXELS: f64 = 16.0;
-
     /// Create an empty canvas.
     pub fn new() -> Self {
         Self {
@@ -51,9 +47,9 @@ impl Canvas {
             return None;
         }
 
-        let x = pos.x as usize / (Self::PIXELS as usize) + 1;
-        let y = pos.y as usize / (Self::PIXELS as usize) + 1;
-        if x > Self::COLS || y > Self::ROWS {
+        let x = pos.x as usize / (theme::PIXEL_SIZE as usize) + 1;
+        let y = pos.y as usize / (theme::PIXEL_SIZE as usize) + 1;
+        if x > theme::COLS || y > theme::ROWS {
             return None;
         }
 
@@ -68,41 +64,30 @@ impl Canvas {
     fn canvas_coords_to_screen_coords_f64(x: f64, y: f64) -> druid::Point {
         assert!(x > 0.0 && y > 0.0);
         druid::Point::new(
-            1.0 + ((x - 1.0) * Self::PIXELS),
-            1.0 + ((y - 1.0) * Self::PIXELS),
+            1.0 + ((x - 1.0) * theme::PIXEL_SIZE),
+            1.0 + ((y - 1.0) * theme::PIXEL_SIZE),
         )
     }
 
-    /// Convert an index within the canvas storage to screen coordinates.
-    fn idx_to_screen_coords(idx: usize) -> druid::Point {
-        let y = (idx / Self::COLS) as f64;
-        let x = (idx % Self::COLS) as f64;
-        druid::Point::new(1.0 + (x * Self::PIXELS), 1.0 + (y * Self::PIXELS))
-    }
-
     /// Convert an index within the canvas storage to a rectanble in screen coordinates.
-    fn idx_to_screen_rect(idx: usize) -> druid::Rect {
-        let origin = Self::idx_to_screen_coords(idx);
-        druid::Rect::from_origin_size(origin, (Self::PIXELS, Self::PIXELS))
+    fn screen_rect(x: usize, y: usize) -> druid::Rect {
+        let fx = (x - 1) as f64;
+        let fy = (y - 1) as f64;
+
+        let origin = druid::Point::new(
+            1.0 + (fx * theme::PIXEL_SIZE),
+            1.0 + (fy * theme::PIXEL_SIZE),
+        );
+
+        druid::Rect::from_origin_size(origin, (theme::PIXEL_SIZE, theme::PIXEL_SIZE))
     }
 
-    /// Paint an index into canvas storage into the given render context.
-    fn paint_idx(ctx: &mut PaintCtx, idx: usize, color: &druid::Color) {
-        let rect = Self::idx_to_screen_rect(idx);
-
-        let (_, _, _, a) = color.as_rgba8();
-        if a != 255 {
-            let y = idx / Self::COLS;
-            let x = idx % Self::ROWS;
-
-            let fill_color = match (x + y) % 2 {
-                0 => theme::CANVAS_FILL_DARK,
-                _ => theme::CANVAS_FILL_LIGHT,
-            };
-            ctx.fill(rect, &fill_color);
+    fn read_safe(data: &AppState, p: druid::Point) -> druid::Color {
+        if data.doc().pixels().contains(p) {
+            data.doc().pixels().read(p)
+        } else {
+            druid::Color::rgba8(0, 0, 0, 0)
         }
-
-        ctx.fill(rect, color);
     }
 
     /// Paint border. The canvas does this internally instead of via border() because the
@@ -114,13 +99,33 @@ impl Canvas {
         ctx.stroke(rect, &color, 1.0);
     }
 
+    fn paint_pixel(ctx: &mut PaintCtx, x: usize, y: usize, color: &druid::Color) {
+        let rect = Self::screen_rect(x, y);
+
+        let (_, _, _, a) = color.as_rgba8();
+        if a != 255 {
+            let fill_color = match (x + y) % 2 {
+                0 => theme::CANVAS_FILL_DARK,
+                _ => theme::CANVAS_FILL_LIGHT,
+            };
+            ctx.fill(rect, &fill_color);
+        }
+
+        ctx.fill(rect, color);
+    }
+
     /// Paint pixels from storage onto the given render context. This will paint
     /// on top of the checkboard. Pixel transparency is via alpha value.
     fn paint_pixels(&self, ctx: &mut PaintCtx, data: &AppState) {
-        //let pixels = data.doc().pixels();
-        //for i in 0..pixels.len() {
-        //    Self::paint_idx(ctx, i, &pixels.read(i));
-        //}
+        let height = data.doc().pixels().header().height();
+        let width = data.doc().pixels().header().width();
+
+        for y in 1..height + 1 {
+            for x in 1..width + 1 {
+                let color = data.doc().pixels().read_xy(x, y);
+                Self::paint_pixel(ctx, x, y, &color);
+            }
+        }
     }
 
     /// Paint a grid line onto the given render context.
@@ -145,11 +150,14 @@ impl Canvas {
     /// Paint the grid onto the given render context.
     fn paint_grid(&self, ctx: &mut PaintCtx, data: &AppState) {
         if data.show_grid() {
-            let num_lines = Self::COLS / 8 + 1;
+            let height = data.doc().pixels().header().height();
+            let width = data.doc().pixels().header().width();
+
+            let num_lines = width / 8 + 1;
             for i in 1..num_lines {
                 let offset = 1 + i * 8;
-                self.paint_grid_line(ctx, offset, 1, offset, Self::ROWS + 1);
-                self.paint_grid_line(ctx, 1, offset, Self::COLS + 1, offset);
+                self.paint_grid_line(ctx, offset, 1, offset, width + 1);
+                self.paint_grid_line(ctx, 1, offset, height + 1, offset);
             }
         }
     }
@@ -182,7 +190,7 @@ impl Canvas {
     fn tool(&mut self, ctx: &mut EventCtx, data: &mut AppState, p: druid::Point) {
         match data.tool_type() {
             ToolType::Dropper => {
-                let color = data.doc().pixels().read(p);
+                let color = Self::read_safe(data, p);
                 data.set_brush_color(color);
             }
 
@@ -262,7 +270,7 @@ impl druid::Widget<AppState> for Canvas {
                         // canvas coords have changed (because of how big our pixels are).
                         // Avoid doing any work if we're still in the same place.
                         if p != data.current_pos() {
-                            let color = data.doc().pixels().read(p);
+                            let color = Self::read_safe(data, p);
 
                             data.set_pos_color(color);
                             data.set_current_pos(p);
@@ -311,7 +319,7 @@ impl druid::Widget<AppState> for Canvas {
         _data: &AppState,
         _env: &Env,
     ) -> Size {
-        let rect = Self::idx_to_screen_rect(Self::ROWS * Self::COLS - 1);
+        let rect = Self::screen_rect(theme::ROWS, theme::COLS);
         let size = Size::new(rect.x1 + 1.0, rect.y1 + 1.0);
         bc.constrain(size)
     }

--- a/src/view/palette.rs
+++ b/src/view/palette.rs
@@ -27,10 +27,6 @@ pub struct Palette {
 }
 
 impl Palette {
-    const COLS: usize = 32;
-    const ROWS: usize = 8;
-    const PIXELS: f64 = 15.0;
-
     /// Create a new palette with the given raw byte values.
     pub fn new(bytes: &[u8]) -> Self {
         Self {
@@ -63,9 +59,9 @@ impl Palette {
             return None;
         }
 
-        let x = pos.x as usize / ((Self::PIXELS as usize) + 1) + 1;
-        let y = pos.y as usize / ((Self::PIXELS as usize) + 1) + 1;
-        if x > Self::COLS || y > Self::ROWS {
+        let x = pos.x as usize / ((theme::PALETTE_PIXEL_SIZE as usize) + 1) + 1;
+        let y = pos.y as usize / ((theme::PALETTE_PIXEL_SIZE as usize) + 1) + 1;
+        if x > theme::PALETTE_COLS || y > theme::PALETTE_ROWS {
             return None;
         }
 
@@ -74,23 +70,28 @@ impl Palette {
 
     /// Convert coordinates to an index within the palette storage.
     fn palette_coords_to_idx(p: druid::Point) -> usize {
-        ((p.y - 1.0) * (Self::COLS as f64) + (p.x - 1.0)) as usize
+        ((p.y - 1.0) * (theme::PALETTE_COLS as f64) + (p.x - 1.0)) as usize
     }
 
     /// Convert an index within the palette storage to screen coordinates.
     fn idx_to_screen_coords(idx: usize) -> druid::Point {
-        let y = (idx / Self::COLS) as f64;
-        let x = (idx % Self::COLS) as f64;
+        let y = (idx / theme::PALETTE_COLS) as f64;
+        let x = (idx % theme::PALETTE_COLS) as f64;
+
         druid::Point::new(
-            1.0 + (x * (Self::PIXELS + 1.0)),
-            1.0 + (y * (Self::PIXELS + 1.0)),
+            1.0 + (x * (theme::PALETTE_PIXEL_SIZE + 1.0)),
+            1.0 + (y * (theme::PALETTE_PIXEL_SIZE + 1.0)),
         )
     }
 
     /// Convert an index within the palette storage to a rectanble in screen coordinates.
     fn idx_to_screen_rect(idx: usize) -> druid::Rect {
         let origin = Self::idx_to_screen_coords(idx);
-        druid::Rect::from_origin_size(origin, (Self::PIXELS, Self::PIXELS))
+
+        druid::Rect::from_origin_size(
+            origin,
+            (theme::PALETTE_PIXEL_SIZE, theme::PALETTE_PIXEL_SIZE),
+        )
     }
 
     /// Paint an index into palette storage into the given render context.

--- a/src/view/theme.rs
+++ b/src/view/theme.rs
@@ -14,6 +14,11 @@
 
 use druid::Color;
 
+pub const ROWS: usize = 48;
+pub const COLS: usize = 48;
+
+pub const PIXEL_SIZE: f64 = 16.0;
+
 pub const MAIN_FILL: Color = Color::rgb8(240, 240, 240);
 pub const MAIN_STROKE: Color = Color::rgb8(208, 208, 208);
 
@@ -29,7 +34,7 @@ pub const COLOR_WELL_SIZE: druid::Size = druid::Size::new(88.0, 30.0);
 
 pub const PREVIEW_FILL: Color = CANVAS_FILL_LIGHT;
 pub const PREVIEW_STROKE: Color = MAIN_STROKE;
-pub const PREVIEW_SIZE: druid::Size = druid::Size::new(32.0, 32.0);
+pub const PREVIEW_SIZE: druid::Size = druid::Size::new(ROWS as f64, COLS as f64);
 
 pub const PALETTE_FILL: Color = Color::BLACK;
 pub const PALETTE_STROKE_SELECTED: Color = Color::BLACK;

--- a/src/view/theme.rs
+++ b/src/view/theme.rs
@@ -35,7 +35,7 @@ pub const PALETTE_FILL: Color = Color::BLACK;
 pub const PALETTE_STROKE_SELECTED: Color = Color::BLACK;
 pub const PALETTE_COLS: usize = 8;
 pub const PALETTE_ROWS: usize = 32;
-pub const PALETTE_PIXEL_SIZE: f64 = 15.0;
+pub const PALETTE_PIXEL_SIZE: f64 = 12.0;
 
 pub const CANVAS_FILL_DARK: Color = Color::rgb8(80, 80, 80);
 pub const CANVAS_FILL_LIGHT: Color = Color::rgb8(96, 96, 96);
@@ -53,7 +53,7 @@ pub const BUTTON_DEFAULT_LIGHT: Color = Color::rgb8(0, 124, 252);
 pub const BUTTON_DARK: Color = Color::rgb8(180, 180, 180);
 pub const BUTTON_LIGHT: Color = Color::rgb8(200, 200, 200);
 
-pub const WINDOW_SIZE: druid::Size = druid::Size::new(980.0, 824.0);
+pub const WINDOW_SIZE: druid::Size = druid::Size::new(960.0, 816.0);
 pub const UNSAVED_FILE_ALERT_SIZE: druid::Size = druid::Size::new(208.0, 212.0);
 pub const WARNING_ALERT_SIZE: druid::Size = druid::Size::new(208.0, 108.0);
 

--- a/src/view/theme.rs
+++ b/src/view/theme.rs
@@ -14,11 +14,6 @@
 
 use druid::Color;
 
-pub const ROWS: usize = 48;
-pub const COLS: usize = 48;
-
-pub const PIXEL_SIZE: f64 = 16.0;
-
 pub const MAIN_FILL: Color = Color::rgb8(240, 240, 240);
 pub const MAIN_STROKE: Color = Color::rgb8(208, 208, 208);
 
@@ -34,7 +29,7 @@ pub const COLOR_WELL_SIZE: druid::Size = druid::Size::new(88.0, 30.0);
 
 pub const PREVIEW_FILL: Color = CANVAS_FILL_LIGHT;
 pub const PREVIEW_STROKE: Color = MAIN_STROKE;
-pub const PREVIEW_SIZE: druid::Size = druid::Size::new(ROWS as f64, COLS as f64);
+pub const PREVIEW_SIZE: druid::Size = druid::Size::new(CANVAS_ROWS as f64, CANVAS_COLS as f64);
 
 pub const PALETTE_FILL: Color = Color::BLACK;
 pub const PALETTE_STROKE_SELECTED: Color = Color::BLACK;
@@ -46,6 +41,9 @@ pub const CANVAS_STROKE_SELECTED_DARK: Color = Color::BLACK;
 pub const CANVAS_STROKE_SELECTED_LIGHT: Color = Color::WHITE;
 pub const CANVAS_STROKE_GRID_DARK: Color = Color::BLACK;
 pub const CANVAS_STROKE_GRID_LIGHT: Color = MAIN_STROKE;
+pub const CANVAS_ROWS: usize = 48;
+pub const CANVAS_COLS: usize = 48;
+pub const CANVAS_PIXEL_SIZE: f64 = 16.0;
 
 pub const BUTTON_DEFAULT_DARK: Color = Color::rgb8(0, 92, 252);
 pub const BUTTON_DEFAULT_LIGHT: Color = Color::rgb8(0, 124, 252);

--- a/src/view/theme.rs
+++ b/src/view/theme.rs
@@ -25,7 +25,7 @@ pub const STATUS_BAR_FILL: Color = MAIN_FILL;
 pub const STATUS_BAR_STROKE: Color = Color::BLACK;
 
 pub const COLOR_WELL_STROKE: Color = MAIN_STROKE;
-pub const COLOR_WELL_SIZE: druid::Size = druid::Size::new(88.0, 30.0);
+pub const COLOR_WELL_SIZE: druid::Size = druid::Size::new(70.0, 30.0);
 
 pub const PREVIEW_FILL: Color = CANVAS_FILL_LIGHT;
 pub const PREVIEW_STROKE: Color = MAIN_STROKE;
@@ -53,7 +53,7 @@ pub const BUTTON_DEFAULT_LIGHT: Color = Color::rgb8(0, 124, 252);
 pub const BUTTON_DARK: Color = Color::rgb8(180, 180, 180);
 pub const BUTTON_LIGHT: Color = Color::rgb8(200, 200, 200);
 
-pub const WINDOW_SIZE: druid::Size = druid::Size::new(672.0, 696.0);
+pub const WINDOW_SIZE: druid::Size = druid::Size::new(980.0, 824.0);
 pub const UNSAVED_FILE_ALERT_SIZE: druid::Size = druid::Size::new(208.0, 212.0);
 pub const WARNING_ALERT_SIZE: druid::Size = druid::Size::new(208.0, 108.0);
 

--- a/src/view/theme.rs
+++ b/src/view/theme.rs
@@ -33,6 +33,9 @@ pub const PREVIEW_SIZE: druid::Size = druid::Size::new(CANVAS_ROWS as f64, CANVA
 
 pub const PALETTE_FILL: Color = Color::BLACK;
 pub const PALETTE_STROKE_SELECTED: Color = Color::BLACK;
+pub const PALETTE_COLS: usize = 8;
+pub const PALETTE_ROWS: usize = 32;
+pub const PALETTE_PIXEL_SIZE: f64 = 15.0;
 
 pub const CANVAS_FILL_DARK: Color = Color::rgb8(80, 80, 80);
 pub const CANVAS_FILL_LIGHT: Color = Color::rgb8(96, 96, 96);

--- a/src/view/window.rs
+++ b/src/view/window.rs
@@ -103,10 +103,12 @@ fn build_color_well() -> impl druid::Widget<AppState> {
 
 fn build_left_pane() -> impl druid::Widget<AppState> {
     Flex::column()
-        .cross_axis_alignment(druid::widget::CrossAxisAlignment::End)
+        .cross_axis_alignment(druid::widget::CrossAxisAlignment::Center)
         .with_child(build_tools())
         .with_default_spacer()
         .with_child(build_color_well())
+        .with_default_spacer()
+        .with_child(build_palette())
 }
 
 fn build_canvas() -> impl druid::Widget<AppState> {
@@ -150,8 +152,6 @@ fn build_center_pane() -> impl druid::Widget<AppState> {
     Flex::column()
         .cross_axis_alignment(druid::widget::CrossAxisAlignment::End)
         .with_child(build_canvas())
-        .with_default_spacer()
-        .with_child(build_palette())
         .with_default_spacer()
         .with_child(build_status_bar())
         .with_default_spacer()

--- a/src/view/window.rs
+++ b/src/view/window.rs
@@ -108,6 +108,7 @@ fn build_left_pane() -> impl druid::Widget<AppState> {
         .with_default_spacer()
         .with_child(build_color_well())
         .with_default_spacer()
+        .with_default_spacer()
         .with_child(build_palette())
 }
 

--- a/src/view/window.rs
+++ b/src/view/window.rs
@@ -128,7 +128,9 @@ fn build_preview() -> impl druid::Widget<AppState> {
 
         for y in 0..height {
             for x in 0..width {
-                let rect = druid::Rect::new(x as f64, y as f64, (x as f64) + 1.0, (y as f64) + 1.0);
+                let fx = x as f64;
+                let fy = y as f64;
+                let rect = druid::Rect::new(fx, fy, fx + 1.0, fy + 1.0);
 
                 let color = pixels.read_xy(x + 1, y + 1);
                 let (_, _, _, a) = color.as_rgba8();

--- a/src/view/window.rs
+++ b/src/view/window.rs
@@ -121,20 +121,17 @@ fn build_preview() -> impl druid::Widget<AppState> {
     druid::widget::Painter::new(|ctx, data: &AppState, _env| {
         let pixels = data.doc().pixels();
         let header = pixels.header();
-        let mut i = 0;
         for y in 0..header.height() {
             for x in 0..header.width() {
                 let rect = druid::Rect::new(x as f64, y as f64, (x as f64) + 1.0, (y as f64) + 1.0);
 
-                let color = pixels.read(i);
+                let color = pixels.read_xy(x, y);
                 let (_, _, _, a) = color.as_rgba8();
                 if a != 255 {
                     ctx.fill(rect, &theme::PREVIEW_FILL);
                 };
 
                 ctx.fill(rect, &color);
-
-                i += 1;
             }
         }
     })

--- a/src/view/window.rs
+++ b/src/view/window.rs
@@ -123,11 +123,11 @@ fn build_preview() -> impl druid::Widget<AppState> {
         let height = pixels.header().height();
         let width = pixels.header().width();
 
-        for y in 1..height + 1 {
-            for x in 1..width + 1 {
+        for y in 0..height {
+            for x in 0..width {
                 let rect = druid::Rect::new(x as f64, y as f64, (x as f64) + 1.0, (y as f64) + 1.0);
 
-                let color = pixels.read_xy(x, y);
+                let color = pixels.read_xy(x + 1, y + 1);
                 let (_, _, _, a) = color.as_rgba8();
                 if a != 255 {
                     ctx.fill(rect, &theme::PREVIEW_FILL);

--- a/src/view/window.rs
+++ b/src/view/window.rs
@@ -120,9 +120,11 @@ fn build_palette() -> impl druid::Widget<AppState> {
 fn build_preview() -> impl druid::Widget<AppState> {
     druid::widget::Painter::new(|ctx, data: &AppState, _env| {
         let pixels = data.doc().pixels();
-        let header = pixels.header();
-        for y in 0..header.height() {
-            for x in 0..header.width() {
+        let height = pixels.header().height();
+        let width = pixels.header().width();
+
+        for y in 1..height + 1 {
+            for x in 1..width + 1 {
                 let rect = druid::Rect::new(x as f64, y as f64, (x as f64) + 1.0, (y as f64) + 1.0);
 
                 let color = pixels.read_xy(x, y);
@@ -130,7 +132,6 @@ fn build_preview() -> impl druid::Widget<AppState> {
                 if a != 255 {
                     ctx.fill(rect, &theme::PREVIEW_FILL);
                 };
-
                 ctx.fill(rect, &color);
             }
         }


### PR DESCRIPTION
Let's bump it up to 48x48. This exposed a ton of bugs, the worst being that I'd tied the canvas and image size together. The indexing system was especially egregious. An index into the canvas does not translate into an index into the pixels. This PR separates the two, such that the image can be any size up to the max. You can finally load smaller pngs, as well as larger ones.