### PR TITLE
Make move tool work

### DIFF
--- a/src/common/commands.rs
+++ b/src/common/commands.rs
@@ -31,6 +31,7 @@ pub const IMAGE_ERASER: Selector<ToolState> = Selector::new("image-eraser");
 pub const IMAGE_FILL: Selector<bool> = Selector::new("image-fill");
 pub const IMAGE_MARQUEE: Selector<ToolState> = Selector::new("image-marquee");
 pub const IMAGE_MOVE: Selector<ToolState> = Selector::new("image-move");
+pub const IMAGE_MOVE_DROP: Selector = Selector::new("image-move-drop");
 pub const IMAGE_PAINT: Selector<ToolState> = Selector::new("image-paint");
 
 pub const VIEW_SHOW_GRID: Selector = Selector::new("view-show-grid");

--- a/src/common/commands.rs
+++ b/src/common/commands.rs
@@ -30,7 +30,7 @@ pub const IMAGE_DITHER_FLOYD: Selector = Selector::new("image-dither-floyd");
 pub const IMAGE_ERASER: Selector<ToolState> = Selector::new("image-eraser");
 pub const IMAGE_FILL: Selector<bool> = Selector::new("image-fill");
 pub const IMAGE_MARQUEE: Selector<ToolState> = Selector::new("image-marquee");
-pub const IMAGE_MOVE: Selector = Selector::new("image-move");
+pub const IMAGE_MOVE: Selector<ToolState> = Selector::new("image-move");
 pub const IMAGE_PAINT: Selector<ToolState> = Selector::new("image-paint");
 
 pub const VIEW_SHOW_GRID: Selector = Selector::new("view-show-grid");

--- a/src/common/commands.rs
+++ b/src/common/commands.rs
@@ -14,6 +14,8 @@
 
 use druid::Selector;
 
+use crate::model::types::ToolState;
+
 pub const EDIT_SELECT_ALL: Selector = Selector::new("edit-select-all");
 pub const EDIT_DESELECT: Selector = Selector::new("edit-deselect");
 
@@ -25,10 +27,10 @@ pub const IMAGE_CLEAR: Selector = Selector::new("image-clear");
 pub const IMAGE_DARKEN: Selector = Selector::new("image-darken");
 pub const IMAGE_DESATURATE: Selector = Selector::new("image-desaturate");
 pub const IMAGE_DITHER_FLOYD: Selector = Selector::new("image-dither-floyd");
-pub const IMAGE_ERASER: Selector = Selector::new("image-eraser");
+pub const IMAGE_ERASER: Selector<ToolState> = Selector::new("image-eraser");
 pub const IMAGE_FILL: Selector<bool> = Selector::new("image-fill");
-pub const IMAGE_MARQUEE: Selector = Selector::new("image-marquee");
+pub const IMAGE_MARQUEE: Selector<ToolState> = Selector::new("image-marquee");
 pub const IMAGE_MOVE: Selector = Selector::new("image-move");
-pub const IMAGE_PAINT: Selector = Selector::new("image-paint");
+pub const IMAGE_PAINT: Selector<ToolState> = Selector::new("image-paint");
 
 pub const VIEW_SHOW_GRID: Selector = Selector::new("view-show-grid");

--- a/src/controller/delegate.rs
+++ b/src/controller/delegate.rs
@@ -126,6 +126,10 @@ impl druid::AppDelegate<AppState> for Delegate {
                 controller::image::move_(ctx, cmd, data);
                 druid::Handled::Yes
             }
+            _ if cmd.is(commands::IMAGE_MOVE_DROP) => {
+                controller::image::move_drop(ctx, cmd, data);
+                druid::Handled::Yes
+            }
             _ if cmd.is(commands::IMAGE_PAINT) => {
                 controller::image::paint(ctx, cmd, data);
                 druid::Handled::Yes

--- a/src/controller/edit.rs
+++ b/src/controller/edit.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::image;
 use crate::controller::undo;
 use crate::model::app::AppState;
 
@@ -29,13 +30,15 @@ pub fn copy(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, _data: &mut Ap
 
 pub fn paste(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, _data: &mut AppState) {}
 
-pub fn select_all(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
+pub fn select_all(ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppState) {
+    image::move_drop(ctx, cmd, data);
+
     let bounds = data.doc().pixels().header().bounds();
     data.doc.set_selection(bounds);
-    data.doc.clear_move_info();
 }
 
-pub fn deselect(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
+pub fn deselect(ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppState) {
+    image::move_drop(ctx, cmd, data);
+
     data.doc.clear_selection();
-    data.doc.clear_move_info();
 }

--- a/src/controller/edit.rs
+++ b/src/controller/edit.rs
@@ -32,9 +32,10 @@ pub fn paste(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, _data: &mut A
 pub fn select_all(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
     let bounds = data.doc().pixels().header().bounds();
     data.doc.set_selection(bounds);
+    data.doc.clear_move_info();
 }
 
 pub fn deselect(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
     data.doc.clear_selection();
-    data.doc.clear_move_bytes();
+    data.doc.clear_move_info();
 }

--- a/src/controller/image.rs
+++ b/src/controller/image.rs
@@ -78,12 +78,14 @@ pub fn move_(ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppS
     if let Some(selection) = data.doc().selection() {
         match *cmd.get_unchecked(commands::IMAGE_MOVE) {
             ToolState::Down => {
-                let current_pos = data.current_pos();
-                let bytes = data.doc().pixels().read_area(selection);
-                let move_info = MoveInfo::new(current_pos, selection, bytes);
-                data.doc.set_move_info(move_info);
+                if !data.doc().is_moving() {
+                    let current_pos = data.current_pos();
+                    let bytes = data.doc().pixels().read_area(selection);
+                    let move_info = MoveInfo::new(current_pos, selection, bytes);
+                    data.doc.set_move_info(move_info);
 
-                clear(ctx, cmd, data);
+                    clear(ctx, cmd, data);
+                }
             }
 
             ToolState::Move => {
@@ -103,7 +105,7 @@ pub fn move_(ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppS
                 }
             }
 
-            ToolState::Up => {}
+            _ => {}
         };
     }
 }

--- a/src/controller/image.rs
+++ b/src/controller/image.rs
@@ -80,8 +80,10 @@ pub fn move_(ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppS
             ToolState::Down => {
                 if !data.doc().is_moving() {
                     let current_pos = data.current_pos();
-                    let bytes = data.doc().pixels().read_area(selection);
-                    let move_info = MoveInfo::new(current_pos, selection, bytes);
+                    let clone_rect = shapes::inflate_rect(selection);
+                    let pixels = data.doc().pixels().clone_area(clone_rect);
+
+                    let move_info = MoveInfo::new(current_pos, selection, pixels);
                     data.doc.set_move_info(move_info);
 
                     clear(ctx, cmd, data);

--- a/src/controller/image.rs
+++ b/src/controller/image.rs
@@ -97,14 +97,12 @@ pub fn move_(ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppS
                     let current_pos = data.current_pos();
                     let offset = move_info.offset();
 
-                    let rect = druid::Rect::new(
-                        current_pos.x - offset.x,
-                        current_pos.y - offset.y,
-                        (current_pos.x - offset.x) + selection.width(),
-                        (current_pos.y - offset.y) + selection.height(),
+                    let point_rect = druid::Rect::from_origin_size(
+                        (current_pos.x, current_pos.y),
+                        (selection.width(), selection.height()),
                     );
-
-                    let new_selection = constrain(rect, bounds);
+                    let rect = offset_rect(point_rect, offset);
+                    let new_selection = constrain_rect(rect, bounds);
 
                     data.doc.set_selection(new_selection);
                 }
@@ -125,7 +123,16 @@ pub fn paint(_ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut App
     }
 }
 
-fn constrain(area: druid::Rect, bounds: druid::Rect) -> druid::Rect {
+fn offset_rect(area: druid::Rect, by: druid::Point) -> druid::Rect {
+    druid::Rect::new(
+        area.x0 - by.x,
+        area.y0 - by.y,
+        area.x1 - by.x,
+        area.y1 - by.y,
+    )
+}
+
+fn constrain_rect(area: druid::Rect, bounds: druid::Rect) -> druid::Rect {
     let width = area.width();
     let height = area.height();
 

--- a/src/controller/image.rs
+++ b/src/controller/image.rs
@@ -15,6 +15,7 @@
 use crate::common::commands;
 use crate::controller::undo;
 use crate::model::app::AppState;
+use crate::model::types::*;
 use crate::transforms;
 
 pub fn black_and_white(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
@@ -41,12 +42,14 @@ pub fn dither_floyd(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: 
     transforms::apply(data, transforms::colors::dither_floyd, 0.0);
 }
 
-pub fn eraser(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
-    let current_pos = data.current_pos();
-    undo::push_point(data, current_pos);
+pub fn eraser(_ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppState) {
+    if *cmd.get_unchecked(commands::IMAGE_ERASER) != ToolState::Up {
+        let current_pos = data.current_pos();
+        undo::push_point(data, current_pos);
 
-    let color = druid::Color::rgba8(0, 0, 0, 0);
-    data.doc.pixels_mut().write(current_pos, &color);
+        let color = druid::Color::rgba8(0, 0, 0, 0);
+        data.doc.pixels_mut().write(current_pos, &color);
+    }
 }
 
 pub fn fill(_ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppState) {
@@ -77,10 +80,12 @@ pub fn marquee(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut 
 
 pub fn move_(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, _data: &mut AppState) {}
 
-pub fn paint(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut AppState) {
-    let current_pos = data.current_pos();
-    undo::push_point(data, current_pos);
+pub fn paint(_ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppState) {
+    if *cmd.get_unchecked(commands::IMAGE_PAINT) != ToolState::Up {
+        let current_pos = data.current_pos();
+        undo::push_point(data, current_pos);
 
-    let color = data.brush_color().clone();
-    data.doc.pixels_mut().write(current_pos, &color);
+        let color = data.brush_color().clone();
+        data.doc.pixels_mut().write(current_pos, &color);
+    }
 }

--- a/src/controller/image.rs
+++ b/src/controller/image.rs
@@ -78,7 +78,30 @@ pub fn marquee(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut 
     }
 }
 
-pub fn move_(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, _data: &mut AppState) {}
+pub fn move_(ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppState) {
+    if data.doc.selection().is_none() {
+        print!("NO SELECTION\n");
+        return;
+    }
+
+    let selection = data.doc().selection().unwrap();
+
+    match *cmd.get_unchecked(commands::IMAGE_MOVE) {
+        ToolState::Down => {
+            print!("START MOVE\n");
+            //data.doc.set_move_bytes();
+            //clear(ctx, cmd, data);
+        }
+
+        ToolState::Move => {
+            print!("MOVING\n");
+        }
+
+        ToolState::Up => {
+            print!("DONE MOVING\n");
+        }
+    };
+}
 
 pub fn paint(_ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppState) {
     if *cmd.get_unchecked(commands::IMAGE_PAINT) != ToolState::Up {

--- a/src/controller/image.rs
+++ b/src/controller/image.rs
@@ -45,7 +45,7 @@ pub fn dither_floyd(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: 
 }
 
 pub fn eraser(_ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppState) {
-    if *cmd.get_unchecked(commands::IMAGE_ERASER) != ToolState::Up {
+    if *cmd.get_unchecked(commands::IMAGE_ERASER) != ToolState::End {
         let current_pos = data.current_pos();
         undo::push_point(data, current_pos);
 
@@ -77,7 +77,7 @@ pub fn marquee(_ctx: &mut druid::DelegateCtx, _cmd: &druid::Command, data: &mut 
 pub fn move_(ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppState) {
     if let Some(selection) = data.doc().selection() {
         match *cmd.get_unchecked(commands::IMAGE_MOVE) {
-            ToolState::Down => {
+            ToolState::Start => {
                 if !data.doc().is_moving() {
                     let current_pos = data.current_pos();
                     let clone_rect = shapes::inflate_rect(selection);
@@ -113,7 +113,7 @@ pub fn move_(ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppS
 }
 
 pub fn paint(_ctx: &mut druid::DelegateCtx, cmd: &druid::Command, data: &mut AppState) {
-    if *cmd.get_unchecked(commands::IMAGE_PAINT) != ToolState::Up {
+    if *cmd.get_unchecked(commands::IMAGE_PAINT) != ToolState::End {
         let current_pos = data.current_pos();
         undo::push_point(data, current_pos);
 

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -34,16 +34,12 @@ impl MoveInfo {
         }
     }
 
-    pub fn start_point(&self) -> druid::Point {
-        self.start_point
-    }
-
-    pub fn start_area(&self) -> druid::Rect {
-        self.start_area
-    }
-
-    pub fn bytes(&self) -> &PixelBytes {
+    pub fn _bytes(&self) -> &PixelBytes {
         &self.bytes
+    }
+
+    pub fn offset(&self) -> druid::Point {
+        self.start_point - (self.start_area.x0, self.start_area.y0)
     }
 }
 
@@ -80,12 +76,12 @@ impl Document {
         self.selection = Some(selection);
     }
 
-    pub fn is_moving(&self) -> bool {
+    pub fn _is_moving(&self) -> bool {
         self.move_info.is_some()
     }
 
-    pub fn move_info(&self) -> &Option<MoveInfo> {
-        &self.move_info
+    pub fn move_info(&self) -> Option<&MoveInfo> {
+        self.move_info.as_ref()
     }
 
     pub fn clear_move_info(&mut self) {

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -12,15 +12,46 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use crate::model::mod_stack::ModStack;
 use crate::model::pixels::PixelState;
 use crate::model::types::*;
+
+#[derive(Clone, druid::Data, Default)]
+pub struct MoveInfo {
+    start_point: druid::Point,
+    start_area: druid::Rect,
+    bytes: PixelBytes,
+}
+
+impl MoveInfo {
+    pub fn new(start_point: druid::Point, start_area: druid::Rect, bytes: Vec<u8>) -> Self {
+        Self {
+            start_point,
+            start_area,
+            bytes: Arc::new(bytes),
+        }
+    }
+
+    pub fn start_point(&self) -> druid::Point {
+        self.start_point
+    }
+
+    pub fn start_area(&self) -> druid::Rect {
+        self.start_area
+    }
+
+    pub fn bytes(&self) -> &PixelBytes {
+        &self.bytes
+    }
+}
 
 /// Per-document state.
 #[derive(Clone, druid::Data, Default)]
 pub struct Document {
     selection: Option<druid::Rect>,
-    move_bytes: Option<PixelBytes>,
+    move_info: Option<MoveInfo>,
     pixels: PixelState,
     path: Option<String>,
     new_path: Option<String>,
@@ -49,12 +80,20 @@ impl Document {
         self.selection = Some(selection);
     }
 
-    pub fn move_bytes(&self) -> &Option<PixelBytes> {
-        &self.move_bytes
+    pub fn is_moving(&self) -> bool {
+        self.move_info.is_some()
     }
 
-    pub fn clear_move_bytes(&mut self) {
-        self.move_bytes = None;
+    pub fn move_info(&self) -> &Option<MoveInfo> {
+        &self.move_info
+    }
+
+    pub fn clear_move_info(&mut self) {
+        self.move_info = None;
+    }
+
+    pub fn set_move_info(&mut self, move_info: MoveInfo) {
+        self.move_info = Some(move_info);
     }
 
     pub fn pixels(&self) -> &PixelState {

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -12,34 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use crate::model::mod_stack::ModStack;
 use crate::model::pixels::PixelState;
-use crate::model::types::*;
 
 #[derive(Clone, druid::Data, Default)]
 pub struct MoveInfo {
     start_point: druid::Point,
     start_area: druid::Rect,
-    bytes: PixelBytes,
+    pixels: PixelState,
 }
 
 impl MoveInfo {
-    pub fn new(start_point: druid::Point, start_area: druid::Rect, bytes: Vec<u8>) -> Self {
+    pub fn new(start_point: druid::Point, start_area: druid::Rect, pixels: PixelState) -> Self {
         Self {
             start_point,
             start_area,
-            bytes: Arc::new(bytes),
+            pixels,
         }
-    }
-
-    pub fn _bytes(&self) -> &PixelBytes {
-        &self.bytes
     }
 
     pub fn offset(&self) -> druid::Point {
         self.start_point - (self.start_area.x0, self.start_area.y0)
+    }
+
+    pub fn pixels(&self) -> &PixelState {
+        &self.pixels
     }
 }
 

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -76,7 +76,7 @@ impl Document {
         self.selection = Some(selection);
     }
 
-    pub fn _is_moving(&self) -> bool {
+    pub fn is_moving(&self) -> bool {
         self.move_info.is_some()
     }
 

--- a/src/model/pixels.rs
+++ b/src/model/pixels.rs
@@ -130,6 +130,21 @@ impl PixelState {
         }
     }
 
+    pub fn clone_area(&self, area: druid::Rect) -> Self {
+        let header = PixelHeader::new(
+            area.width() as u32,
+            area.height() as u32,
+            self.header.depth,
+            self.header.bytes_per_pixel,
+        );
+
+        Self {
+            header,
+            dirty: false,
+            bytes: Arc::new(self.read_area(area)),
+        }
+    }
+
     /// Are pixels dirty?
     pub fn dirty(&self) -> bool {
         self.dirty

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -30,9 +30,9 @@ pub enum ToolType {
 
 #[derive(Clone, Copy, druid::Data, PartialEq)]
 pub enum ToolState {
-    Down,
+    Start,
     Move,
-    Up,
+    End,
 }
 
 /// Window state.

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -28,6 +28,13 @@ pub enum ToolType {
     Paint,
 }
 
+#[derive(Clone, Copy, druid::Data, PartialEq)]
+pub enum ToolState {
+    Down,
+    Move,
+    Up,
+}
+
 /// Window state.
 #[derive(Clone, Copy, druid::Data, PartialEq)]
 pub enum WindowState {

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -30,11 +30,19 @@ where
     let bounds = data.doc().bounds();
     undo::push(data, bounds);
 
+    apply_no_undo(data, f, param);
+}
+
+pub fn apply_no_undo<F>(data: &mut AppState, f: F, param: f64)
+where
+    F: Fn(&PixelHeader, &PixelEnv, &mut Vec<u8>),
+{
     // The transform function gets copies of the header and the bytes. We don't want
     // it mucking directly with our pixels.
     let header = data.doc().pixels().header().clone();
     let brush_color = data.brush_color().clone();
     let current_pos = data.current_pos();
+    let bounds = data.doc().bounds();
     let env = PixelEnv::new(brush_color, current_pos, bounds, param);
     let mut bytes = data.doc().pixels().bytes().to_vec();
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -12,27 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use druid::PlatformError;
-
-mod common;
-mod controller;
-mod model;
-mod storage;
-mod transforms;
-mod util;
-mod view;
-
-use controller::delegate::Delegate;
-use model::app::AppState;
-use view::window;
-
-fn main() -> Result<(), PlatformError> {
-    let window = window::window();
-
-    let data = AppState::new(window.id);
-
-    druid::AppLauncher::with_window(window)
-        .delegate(Delegate)
-        .use_env_tracing()
-        .launch(data)
-}
+pub mod shapes;

--- a/src/util/shapes.rs
+++ b/src/util/shapes.rs
@@ -21,21 +21,25 @@ pub fn enclosing_rect(a: druid::Point, b: druid::Point) -> druid::Rect {
     druid::Rect::new(x0, y0, x1, y1)
 }
 
-pub fn offset_rect(area: druid::Rect, by: druid::Point) -> druid::Rect {
+pub fn inflate_rect(rect: druid::Rect) -> druid::Rect {
+    rect.with_size((rect.width() + 1.0, rect.height() + 1.0))
+}
+
+pub fn offset_rect(rect: druid::Rect, by: druid::Point) -> druid::Rect {
     druid::Rect::new(
-        area.x0 - by.x,
-        area.y0 - by.y,
-        area.x1 - by.x,
-        area.y1 - by.y,
+        rect.x0 - by.x,
+        rect.y0 - by.y,
+        rect.x1 - by.x,
+        rect.y1 - by.y,
     )
 }
 
-pub fn constrain_rect(area: druid::Rect, bounds: druid::Rect) -> druid::Rect {
-    let width = area.width();
-    let height = area.height();
+pub fn constrain_rect(rect: druid::Rect, bounds: druid::Rect) -> druid::Rect {
+    let width = rect.width();
+    let height = rect.height();
 
-    let mut tl = (area.x0, area.y0);
-    let mut br = (area.x1, area.y1);
+    let mut tl = (rect.x0, rect.y0);
+    let mut br = (rect.x1, rect.y1);
 
     if tl.0 < bounds.x0 {
         tl.0 = bounds.x0;

--- a/src/util/shapes.rs
+++ b/src/util/shapes.rs
@@ -1,0 +1,58 @@
+// Copyright 2021 Andy King
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub fn enclosing_rect(a: druid::Point, b: druid::Point) -> druid::Rect {
+    let x0 = a.x.min(b.x);
+    let y0 = a.y.min(b.y);
+    let x1 = a.x.max(b.x);
+    let y1 = a.y.max(b.y);
+
+    druid::Rect::new(x0, y0, x1, y1)
+}
+
+pub fn offset_rect(area: druid::Rect, by: druid::Point) -> druid::Rect {
+    druid::Rect::new(
+        area.x0 - by.x,
+        area.y0 - by.y,
+        area.x1 - by.x,
+        area.y1 - by.y,
+    )
+}
+
+pub fn constrain_rect(area: druid::Rect, bounds: druid::Rect) -> druid::Rect {
+    let width = area.width();
+    let height = area.height();
+
+    let mut tl = (area.x0, area.y0);
+    let mut br = (area.x1, area.y1);
+
+    if tl.0 < bounds.x0 {
+        tl.0 = bounds.x0;
+        br.0 = 1.0 + width;
+    }
+    if tl.1 < bounds.y0 {
+        tl.1 = bounds.y0;
+        br.1 = 1.0 + height;
+    }
+    if br.0 > bounds.x1 {
+        tl.0 = bounds.x1 - width;
+        br.0 = bounds.x1;
+    }
+    if br.1 > bounds.y1 {
+        tl.1 = bounds.y1 - height;
+        br.1 = bounds.y1;
+    }
+
+    druid::Rect::from_points(tl, br)
+}

--- a/src/view/canvas.rs
+++ b/src/view/canvas.rs
@@ -17,6 +17,7 @@ use druid::widget::prelude::*;
 use crate::common::commands;
 use crate::model::app::AppState;
 use crate::model::types::*;
+use crate::util::shapes;
 use crate::view::theme;
 
 /// A canvas that allows for the display and modification of pixels. The size is currently
@@ -109,9 +110,25 @@ impl Canvas {
         let height = header.height();
         let width = header.width();
 
+        let moving = data.doc().is_moving();
+        let dragged_rect = if moving {
+            shapes::inflate_rect(data.doc().selection().unwrap())
+        } else {
+            druid::Rect::ZERO
+        };
+
         for y in 1..height + 1 {
             for x in 1..width + 1 {
-                let color = data.doc().pixels().read_xy_unchecked(x, y);
+                let color = if moving {
+                    let p = druid::Point::new(x as f64, y as f64);
+                    if !dragged_rect.contains(p) {
+                        data.doc().pixels().read_xy_unchecked(x, y)
+                    } else {
+                        druid::Color::rgba8(0, 0, 0, 0)
+                    }
+                } else {
+                    data.doc().pixels().read_xy_unchecked(x, y)
+                };
                 Self::paint_pixel(ctx, x, y, &color);
             }
         }

--- a/src/view/canvas.rs
+++ b/src/view/canvas.rs
@@ -290,7 +290,7 @@ impl druid::Widget<AppState> for Canvas {
                         }
                     }
                     ctx.set_active(true);
-                    self.tool(ctx, data, ToolState::Down);
+                    self.tool(ctx, data, ToolState::Start);
                 }
             }
 
@@ -334,7 +334,7 @@ impl druid::Widget<AppState> for Canvas {
 
             Event::MouseUp(_e) if ctx.is_active() => {
                 ctx.set_active(false);
-                self.tool(ctx, data, ToolState::Up);
+                self.tool(ctx, data, ToolState::End);
             }
 
             _ => {}

--- a/src/view/canvas.rs
+++ b/src/view/canvas.rs
@@ -158,7 +158,12 @@ impl Canvas {
             let tl = Self::canvas_coords_to_screen_coords_f64(s.x0, s.y0);
             let br = Self::canvas_coords_to_screen_coords_f64(s.x1, s.y1);
 
-            let rect = druid::Rect::new(tl.x, tl.y, br.x + 16.0, br.y + 16.0);
+            let rect = druid::Rect::new(
+                tl.x,
+                tl.y,
+                br.x + theme::CANVAS_PIXEL_SIZE,
+                br.y + theme::CANVAS_PIXEL_SIZE,
+            );
 
             ctx.stroke_styled(
                 rect,
@@ -209,7 +214,7 @@ impl Canvas {
             }
 
             ToolType::Move => {
-                ctx.submit_command(commands::IMAGE_MOVE);
+                ctx.submit_command(commands::IMAGE_MOVE.with(state));
             }
 
             ToolType::Paint => {

--- a/src/view/tool.rs
+++ b/src/view/tool.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use druid::widget::prelude::*;
 
+use crate::common::commands;
 use crate::model::app::AppState;
 use crate::model::types::ToolType;
 use crate::view::theme;
@@ -122,7 +123,7 @@ impl<W: Widget<AppState>> druid::widget::Controller<AppState, W> for ToolsContro
         child.event(ctx, event, data, env);
 
         if tool_type != data.tool_type() {
-            data.doc.clear_move_info();
+            ctx.submit_command(commands::IMAGE_MOVE_DROP);
             ctx.request_paint();
         }
     }

--- a/src/view/tool.rs
+++ b/src/view/tool.rs
@@ -52,12 +52,6 @@ impl druid::Widget<AppState> for ToolButton {
             Event::MouseUp(_e) if ctx.is_active() => {
                 if ctx.is_hot() {
                     data.set_tool_type(self.tool_type);
-
-                    // Don't forget to clear out the move bytes. There has to be a better
-                    // place to put this.
-                    if data.tool_type() != ToolType::Move && data.doc().move_bytes().is_some() {
-                        data.doc.clear_move_bytes();
-                    }
                 }
                 ctx.set_active(false);
             }
@@ -115,18 +109,14 @@ impl druid::Widget<AppState> for ToolButton {
 pub struct ToolsController;
 
 impl<W: Widget<AppState>> druid::widget::Controller<AppState, W> for ToolsController {
-    fn update(
-        &mut self,
-        child: &mut W,
-        ctx: &mut UpdateCtx,
-        old_data: &AppState,
-        data: &AppState,
-        env: &Env,
-    ) {
-        if old_data.tool_type() != data.tool_type() {
+    fn event(&mut self, child: &mut W, ctx: &mut EventCtx, event: &Event, data: &mut AppState, env: &Env) {
+        let tool_type = data.tool_type();
+
+        child.event(ctx, event, data, env);
+
+        if tool_type != data.tool_type() {
+            data.doc.clear_move_info();
             ctx.request_paint();
         }
-
-        child.update(ctx, old_data, data, env);
     }
 }

--- a/src/view/tool.rs
+++ b/src/view/tool.rs
@@ -109,7 +109,14 @@ impl druid::Widget<AppState> for ToolButton {
 pub struct ToolsController;
 
 impl<W: Widget<AppState>> druid::widget::Controller<AppState, W> for ToolsController {
-    fn event(&mut self, child: &mut W, ctx: &mut EventCtx, event: &Event, data: &mut AppState, env: &Env) {
+    fn event(
+        &mut self,
+        child: &mut W,
+        ctx: &mut EventCtx,
+        event: &Event,
+        data: &mut AppState,
+        env: &Env,
+    ) {
         let tool_type = data.tool_type();
 
         child.event(ctx, event, data, env);


### PR DESCRIPTION
Finally!

* Introduce a ToolState type so that we can distinguish between the start, move and end of a tool.
* Pickup the selection when the move starts
* Move the selection as the move is, er, moved
* Drop the move when the selection is cleared, not when the move ends. This way you can easily re-move by releasing the mouse and clicking it again, as long as you don't change the selection.
* Provide a way to clone pixel state from a given area, and use that to record what's being dragged. Then we can easily read the pixels when writing it back during painting.
* Don't paint normal pixels and then paint the drag on top. Paint fast, by only painting each pixel once, regardless of where it is stored.